### PR TITLE
Sanctions Component: Fix recursive API calls

### DIFF
--- a/src/app/components/paginated/paginated.component.ts
+++ b/src/app/components/paginated/paginated.component.ts
@@ -254,7 +254,7 @@ export abstract class PaginatedComponent<DTO extends ApiDTO, CLIENT extends Crud
         pageOption.page = page
         pageOption.sort = ""
 
-        this.pacifistaPlayerDataService.find(new PageOption(), queryBuilder).subscribe({
+        this.pacifistaPlayerDataService.find(pageOption, queryBuilder).subscribe({
             next: pageDTO => {
                 data.push(...pageDTO.content)
 


### PR DESCRIPTION
Sanctions Component
Bug in: `src\app\components\paginated\paginated.component.ts`
Description: forgot to use created variable, causing api call to the same page over and over again
En gros c'est un bug stupide mdrr 🤡 
